### PR TITLE
Fixes for JAGS 5.0.0

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -8,5 +8,5 @@ assign("defaultoptions",list(jagspath=expression(findjags()),method=expression(i
 assign("simfolders", character(0), envir=neojagsprivate)
 assign("failedsimfolders", character(0), envir=neojagsprivate)
 assign("minjagsmajor", 3, envir=neojagsprivate)
-assign("maxjagsmajor", 4, envir=neojagsprivate)
+assign("maxjagsmajor", 5, envir=neojagsprivate)
 assign("warned_version_mismatch", FALSE, envir=neojagsprivate)

--- a/src/jagsversions.h
+++ b/src/jagsversions.h
@@ -48,7 +48,7 @@
 #endif // JAGS_MAJOR_ASSUMED
 
 // Check version of JAGS is OK:
-#if JAGS_MAJOR_USED > 4
+#if JAGS_MAJOR_USED > 5
 #warning "Compiling against a later version of JAGS than has been tested for this version of runjags ... you should probably update the runjags package!"
 #endif
 


### PR DESCRIPTION
In preparation for the release of JAGS 5.0.0 I am testing the reverse dependencies of the rjags package on CRAN to ensure that they work with the new version.

The neojags package works perfectly fine with the new JAGS. You just need to move some of the tripwires you put in place to stop users prematurely using neojags with an untested version of JAGS.
